### PR TITLE
BitMEX amend bulk seems to be missing #23

### DIFF
--- a/src/exchanges/sey/bitmex/trade/order.cs
+++ b/src/exchanges/sey/bitmex/trade/order.cs
@@ -241,4 +241,37 @@ namespace CCXT.NET.BitMEX.Trade
             set;
         }
     }
+    
+    /// <summary>
+    /// Items for TradeApi.UpdateOrders call
+    /// </summary>
+    public class BBulkUpdateOrderItem
+    {
+        /// <summary>
+        ///
+        /// </summary>
+        public string orderID
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public decimal orderQty
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public decimal price
+        {
+            get;
+            set;
+        }
+    }
 }

--- a/src/exchanges/sey/bitmex/trade/order.cs
+++ b/src/exchanges/sey/bitmex/trade/order.cs
@@ -240,8 +240,96 @@ namespace CCXT.NET.BitMEX.Trade
             get;
             set;
         }
+
+        /// <summary>
+        /// Ctor. Accepts Typed parameters for convenience.
+        /// </summary>
+        public BBulkOrderItem(string symbol, SideType side, OrderType orderType, decimal orderQty, decimal price, string execInst = "")
+        {
+            this.symbol = symbol;
+            this.side = BSideTypeConverter.ToString(side);
+            this.execInst = execInst;
+            this.ordType = BOrderTypeConverter.ToString(orderType);
+            this.orderQty = orderQty;
+            this.price = price;
+        }
     }
-    
+
+    /// <summary>
+    /// Converter between SideType and string
+    /// </summary>
+    public class BSideTypeConverter
+    {
+        /// <summary>
+        /// string -> SideType
+        /// </summary>
+        public static SideType FromString(string side)
+        {
+            switch (side)
+            {
+                case "Sell":
+                    return SideType.Ask;
+                case "Buy":
+                    return SideType.Bid;
+                default:
+                    return SideType.Unknown;
+            }
+        }
+
+        /// <summary>
+        /// SideType -> string
+        /// </summary>
+        public static string ToString(SideType side)
+        {
+            switch (side)
+            {
+                case SideType.Ask:
+                    return "Sell";
+                case SideType.Bid:
+                    return "Buy";
+                default:
+                    throw new NotSupportedException("Unkown side not supported");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Converter between OrderType and string
+    /// </summary>
+    public class BOrderTypeConverter
+    {
+        /// <summary>
+        /// string -> OrderType
+        /// </summary>
+        public static OrderType FromString(string orderType)
+        {
+            switch (orderType)
+            {
+                case "Limit":
+                    return OrderType.Limit;
+                case "Market":
+                    return OrderType.Market;
+                default:
+                    return OrderType.Unknown;
+            }
+        }
+
+        /// <summary>
+        /// OrderType -> string
+        /// </summary>
+        public static string ToString(OrderType type)
+        {
+            switch (type)
+            {
+                case OrderType.Limit:
+                    return "Limit";
+                case OrderType.Market:
+                    return "Market";
+                default:
+                    throw new NotSupportedException("Unkown or unsupported order type");
+            }
+        }
+    }
     /// <summary>
     /// Items for TradeApi.UpdateOrders call
     /// </summary>
@@ -272,6 +360,11 @@ namespace CCXT.NET.BitMEX.Trade
         {
             get;
             set;
+        }
+
+        public BBulkUpdateOrderItem()
+        {
+
         }
     }
 }

--- a/src/exchanges/sey/bitmex/trade/tradeApi.cs
+++ b/src/exchanges/sey/bitmex/trade/tradeApi.cs
@@ -757,6 +757,45 @@ namespace CCXT.NET.BitMEX.Trade
         }
 
         /// <summary>
+        /// Update orders in bulk.
+        /// </summary>
+        /// <param name="orders"></param>
+        /// <param name="args">Add additional attributes for each exchange</param>
+        /// <returns></returns>
+        public async Task<MyOrders> UpdateOrders(List<BBulkUpdateOrderItem> orders, Dictionary<string, object> args = null)
+        {
+            var _result = new MyOrders();
+
+            tradeClient.ExchangeInfo.ApiCallWait(TradeType.Trade);
+            {
+                var _params = tradeClient.MergeParamsAndArgs(
+                    new Dictionary<string, object>
+                    {
+                        { "orders", orders }
+                    },
+                    args
+                );
+
+                var _json_value = await tradeClient.CallApiPut1Async("/api/v1/order/bulk", _params);
+#if DEBUG
+                _result.rawJson = _json_value.Content;
+#endif
+                var _json_result = tradeClient.GetResponseMessage(_json_value.Response);
+                if (_json_result.success == true)
+                {
+                    var _orders = tradeClient.DeserializeObject<List<BMyOrderItem>>(_json_value.Content);
+                    {
+                        _result.result = _orders.ToList<IMyOrderItem>();
+                    }
+                }
+
+                _result.SetResult(_json_result);
+            }
+
+            return _result;
+        }
+
+        /// <summary>
         /// Cancel an order.
         /// </summary>
         /// <param name="base_name">The type of trading base-currency of which information you want to query for.</param>


### PR DESCRIPTION
Added UpdateOrders to the BitMEX tradeApi for bulk updates.

Example with bulk orders that uses the new functionality added to samples/bitmex.

Also added a constructor to BBulkOrderItem to make it convenient to create bulk orders.