### PR TITLE
set ccxt.net to .NETStandard 2.0 to make it compatiable with more tar…

### DIFF
--- a/samples/binance/binance.csproj
+++ b/samples/binance/binance.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
       <OutputType>Exe</OutputType>
+	  <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bitmex/bitmex.csproj
+++ b/samples/bitmex/bitmex.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+	<TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bittrex/bittrex.csproj
+++ b/samples/bittrex/bittrex.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+	<TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/kraken/kraken.csproj
+++ b/samples/kraken/kraken.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+	<TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ccxt.net.csproj
+++ b/src/ccxt.net.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
         <Title>CryptoCurrency eXchange Trading Library for .NET</Title>
         <Product>CCXT</Product>
         <Company>ODINSOFT</Company>

--- a/tests/ccxt.test/ccxt.test.csproj
+++ b/tests/ccxt.test/ccxt.test.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>ccxt.test</AssemblyName>
     <RootNamespace>CCXT.TEST</RootNamespace>
+	<TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Setted CCXT.NET to DotNETStandard 2.0 instead of .NET 6, since .net standard is compatible with more versions of Dotnet versions
Per: https://docs.microsoft.com/en-us/dotnet/standard/net-standard

Since .net6 is only compatible with .NET 6 or higher version