### PR TITLE
The substring array trading error on Gemini. 

### DIFF
--- a/src/exchanges/usa/gemini/public/publicApi.cs
+++ b/src/exchanges/usa/gemini/public/publicApi.cs
@@ -62,7 +62,7 @@ namespace CCXT.NET.Gemini.Public
                         var _symbol = _market.ToString();
 
                         var _base_id = _symbol.Substring(0, 3);
-                        var _quote_id = _symbol.Substring(3);
+                        var _quote_id = _symbol.Substring(4);
 
                         var _base_name = publicClient.ExchangeInfo.GetCommonCurrencyName(_base_id);
                         var _quote_name = publicClient.ExchangeInfo.GetCommonCurrencyName(_quote_id);


### PR DESCRIPTION
The issue stemmed from certain symbols containing extended quote sequences, which were causing errors. The solution involved adjusting the substring array size to accommodate the longer quote sequences, effectively resolving API trading errors.
